### PR TITLE
fix: handle undefined SPEAKERS array

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,7 @@ export function render(state: State, store: StateStore): RenderResult {
     (state.filterByTags.length === 0 || state.filterByTags.every(filterTag =>
       heading.tags?.map(tag => tag.toLowerCase()).includes(filterTag))) &&
     (state.filterBySpeakers.length === 0 || state.filterBySpeakers.every(filterSpeaker =>
-      heading.drawer?.SPEAKERS.split(',').map(speaker => speaker.trim().toLowerCase()).includes(filterSpeaker.toLowerCase()))) &&
+      heading.drawer?.SPEAKERS?.split(',').map(speaker => speaker.trim().toLowerCase()).includes(filterSpeaker.toLowerCase()))) &&
 			(state.filterByTitle.length === 0 || state.filterByTitle.split(' ').every(filterTitle => headingMatchesSearch(heading, filterTitle.trim().toLowerCase()))));
 
   const randomPick = new RandomPickRenderer(store)


### PR DESCRIPTION
This caused an error when loading: https://emacs.tv/?speakers=Emacs+Elements

<details>
<summary>
Error:
</summary>
<pre>
?speakers=Emacs+Elements:23148 TypeError: Cannot read properties of undefined (reading 'split')
    at ?speakers=Emacs+Elements:22744:336
    at Array.every (<anonymous>)
    at ?speakers=Emacs+Elements:22744:287
    at Array.filter (<anonymous>)
    at Object.render (?speakers=Emacs+Elements:22744:57)
    at ?speakers=Emacs+Elements:22678:49
    at ?speakers=Emacs+Elements:23297:46
    at Set.forEach (<anonymous>)
    at ValueStream.emit (?speakers=Emacs+Elements:23297:24)
    at ValueStream.mutate (?speakers=Emacs+Elements:23308:16)
load @ ?speakers=Emacs+Elements:23148
await in load
(anonymous) @ ?speakers=Emacs+Elements:22695
?speakers=Emacs+Elements:22744 Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'split')
    at ?speakers=Emacs+Elements:22744:336
    at Array.every (<anonymous>)
    at ?speakers=Emacs+Elements:22744:287
    at Array.filter (<anonymous>)
    at Object.render (?speakers=Emacs+Elements:22744:57)
    at ?speakers=Emacs+Elements:22678:49
    at ?speakers=Emacs+Elements:23297:46
    at Set.forEach (<anonymous>)
    at ValueStream.emit (?speakers=Emacs+Elements:23297:24)
    at ValueStream.mutate (?speakers=Emacs+Elements:23308:16)
(anonymous) @ ?speakers=Emacs+Elements:22744
(anonymous) @ ?speakers=Emacs+Elements:22744
render @ ?speakers=Emacs+Elements:22744
(anonymous) @ ?speakers=Emacs+Elements:22678
(anonymous) @ ?speakers=Emacs+Elements:23297
emit @ ?speakers=Emacs+Elements:23297
mutate @ ?speakers=Emacs+Elements:23308
load @ ?speakers=Emacs+Elements:23149
await in load
(anonymous) @ ?speakers=Emacs+Elements:22695
</pre>
</details>

Note: I think this is the right fix, but I don't have an easy way to validate it.